### PR TITLE
Update RawHitFinder_module.cc

### DIFF
--- a/larreco/HitFinder/RawHitFinder_module.cc
+++ b/larreco/HitFinder/RawHitFinder_module.cc
@@ -143,7 +143,7 @@ namespace hit {
       art::Ptr<raw::RawDigit> digitVec(digitVecHandle, rdIter);
       channel = digitVec->Channel();
       fDataSize = digitVec->Samples();
-
+      if(fDataSize==0)continue;
       rawadc.resize(fDataSize);
       holder.resize(fDataSize);
 


### PR DESCRIPTION
Fixed seg fault in RawHitFinder. This Seg fault was discovered when running the module on SBND data.